### PR TITLE
Fix hsp discarded when on frame 0

### DIFF
--- a/includes/tripal_analysis_blast.xml_parser.inc
+++ b/includes/tripal_analysis_blast.xml_parser.inc
@@ -896,7 +896,7 @@ function tripal_analysis_blast_get_result_object($xml_string, $db, $feature_id, 
                 $hits_array[$hit_count]['description'] = $description;
 
                 // if there is at least one HSP
-                if (!empty($hsp_array[0]['query_frame'])) {
+                if (isset($hsp_array[0]['query_frame'])) {
                   $hits_array[$hit_count]['hsp'] = $hsp_array;
                 }
                 else {


### PR DESCRIPTION
!empty() returns false when the frame is "0" (see http://stackoverflow.com/questions/4139301/php-0-as-a-string-with-empty)
isset() should be fine with the expected values
