### PR TITLE
Only add js and css on pages where it is needed

### DIFF
--- a/theme/tripal_analysis_blast.theme.inc
+++ b/theme/tripal_analysis_blast.theme.inc
@@ -4,11 +4,51 @@
  *
 */
 function tripal_analysis_blast_preprocess_tripal_feature_blast_results(&$variables) {
-  $feature = $variables['node']->feature;
-  $db_id = null;
-  //$db_id = $variables['node']->db_id; // this value only gets set on an ajax call
+    $feature = $variables['node']->feature;
+    $db_id = null;
+    //$db_id = $variables['node']->db_id; // this value only gets set on an ajax call
 
-  $blast_results = tripal_get_feature_blast_results($feature->feature_id,  $db_id);
-  $feature->tripal_analysis_blast = new stdClass;
-  $feature->tripal_analysis_blast->blast_results_list = $blast_results;
+    $blast_results = tripal_get_feature_blast_results($feature->feature_id,  $db_id);
+    $feature->tripal_analysis_blast = new stdClass;
+    $feature->tripal_analysis_blast->blast_results_list = $blast_results;
+
+
+    drupal_add_css("https://cdn.rawgit.com/calipho-sib/feature-viewer/v0.1.44/dist/feature-viewer.min.css", array('type' => 'external'));
+
+    // Hack to ensure that jquery 3.1.0 is loaded just before calling noconflict
+    drupal_add_js("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js", array(
+      'type' => 'external',
+      'scope' => 'header',
+      'group' => 15,
+      'every_page' => TRUE,
+      'weight' => 100,
+    ));
+    drupal_add_js("https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js", array(
+      'type' => 'external',
+      'scope' => 'header',
+      'group' => 15,
+      'every_page' => TRUE,
+      'weight' => 200,
+    ));
+    drupal_add_js("https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js", array(
+      'type' => 'external',
+      'scope' => 'header',
+      'group' => 15,
+      'every_page' => TRUE,
+      'weight' => 300,
+    ));
+    drupal_add_js("https://cdn.rawgit.com/calipho-sib/feature-viewer/v0.1.44/dist/feature-viewer.min.js", array(
+      'type' => 'external',
+      'scope' => 'header',
+      'group' => 15,
+      'every_page' => TRUE,
+      'weight' => 400,
+    ));
+    drupal_add_js("if (typeof feature_viewer_jquery == 'undefined') {var feature_viewer_jquery = jQuery.noConflict(true);}", array(
+      'type' => 'inline',
+      'scope' => 'header',
+      'group' => 15,
+      'every_page' => TRUE,
+      'weight' => 1000,
+    ));
 }

--- a/tripal_analysis_blast.module
+++ b/tripal_analysis_blast.module
@@ -7,53 +7,6 @@ require_once "includes/tripal_analysis_blast.chado_node.inc";
 
 require_once "theme/tripal_analysis_blast.theme.inc";
 
-
-/**
- * Implements hook_init().
- */
-function tripal_analysis_blast_init(){
-
-  drupal_add_css("https://cdn.rawgit.com/calipho-sib/feature-viewer/v0.1.44/dist/feature-viewer.min.css", array('type' => 'external'));
-
-  // Hack to ensure that jquery 3.1.0 is loaded just before calling noconflict
-  drupal_add_js("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js", array(
-    'type' => 'external',
-    'scope' => 'header',
-    'group' => 15,
-    'every_page' => TRUE,
-    'weight' => 100,
-  ));
-  drupal_add_js("https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js", array(
-    'type' => 'external',
-    'scope' => 'header',
-    'group' => 15,
-    'every_page' => TRUE,
-    'weight' => 200,
-  ));
-  drupal_add_js("https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js", array(
-    'type' => 'external',
-    'scope' => 'header',
-    'group' => 15,
-    'every_page' => TRUE,
-    'weight' => 300,
-  ));
-  drupal_add_js("https://cdn.rawgit.com/calipho-sib/feature-viewer/v0.1.44/dist/feature-viewer.min.js", array(
-    'type' => 'external',
-    'scope' => 'header',
-    'group' => 15,
-    'every_page' => TRUE,
-    'weight' => 400,
-  ));
-  drupal_add_js("if (typeof feature_viewer_jquery == 'undefined') {var feature_viewer_jquery = jQuery.noConflict(true);}", array(
-    'type' => 'inline',
-    'scope' => 'header',
-    'group' => 15,
-    'every_page' => TRUE,
-    'weight' => 1000,
-  ));
-}
-
-
 /**
  * Implements hook_menu().
  */


### PR DESCRIPTION
This is to only add js and css files on pages where it is needed, with 2 benefits:
-performances
-fixes a compatibility problem between Bootstrap (used here) and google charts used on the organism pages by tripal_analysis_go

(same PR as tripal_analysis_interpro/pull/6)