### PR TITLE
Fix warning when hit_url is absent

### DIFF
--- a/includes/tripal_analysis_blast.xml_parser.inc
+++ b/includes/tripal_analysis_blast.xml_parser.inc
@@ -481,7 +481,7 @@ function tripal_analysis_blast_handle_iteration($blastoutput, $analysis_id, $bla
                 'db_id' => $blastdb,
                 'hit_num' => $i + 1,
                 'hit_name' => $blast_obj->hits_array[$i]['hit_name'],
-                'hit_url' => $blast_obj->hits_array[$i]['hit_url'],
+                'hit_url' => (array_key_exists('hit_url', $blast_obj->hits_array[$i]) ? $blast_obj->hits_array[$i]['hit_url'] : ''),
                 'hit_description' => $blast_obj->hits_array[$i]['description'],
                 'hit_organism' => $blast_org_name,
                 'blast_org_id' => $blast_org_id,


### PR DESCRIPTION
Just a little fix for a notice I repeatedly get everytime I load some blast xml:
`Undefined index: hit_url tripal_analysis_blast.xml_parser.inc:484       [notice]`
