### PR TITLE
Remove not noeeded quotation mark

### DIFF
--- a/includes/TripalFields/format__blast_results/format__blast_results_formatter.inc
+++ b/includes/TripalFields/format__blast_results/format__blast_results_formatter.inc
@@ -147,7 +147,7 @@ class format__blast_results_formatter extends ChadoFieldFormatter {
           '<span title="' . $hit['description'] . '">' . $description . '</span>' .
           // add the [more] link at the end of the row.  Javascript is used
           // to display this record
-          '<a href="javascript:void(0);" id="hsp-link-"' . $analysis->analysis_id . '-' .  $j . '" class="tripal-analysis-blast-info-hsp-link">[more]</a>',
+          '<a href="javascript:void(0);" id="hsp-link-' . $analysis->analysis_id . '-' .  $j . '" class="tripal-analysis-blast-info-hsp-link">[more]</a>',
         );
 
         // add a div box for each HSP details.  This box will be invisible by default


### PR DESCRIPTION
This PR fixes a typo in the `[more]` link that prevented it from creating a correct `id` attribute which prevented it from displaying the additional information popup.

Thanks!