### PR TITLE
Resolve update error

### DIFF
--- a/tripal_analysis_blast.install
+++ b/tripal_analysis_blast.install
@@ -460,11 +460,11 @@ function tripal_analysis_blast_create_entity_type () {
       'type_value' => 'blast_analysis'
     )
   );
-  $term = tripal_load_term_entity(array('vocabulary' => 'format', 'accession' => '1333'));
+  $term = tripal_load_term_entity(array('vocabulary' => 'EDAM', 'accession' => '1333'));
   $bundle = tripal_load_bundle_entity(array('term_id' => $term->id));
   // Add cvterm_mapping for the BLAST results entity type
   $identifier = array(
-    'cv_id' => array('name' => 'format'),
+    'cv_id' => array('name' => 'EDAM'),
     'name' => 'BLAST results'
   );
   $cvterm = tripal_get_cvterm($identifier);

--- a/tripal_analysis_blast.install
+++ b/tripal_analysis_blast.install
@@ -77,13 +77,6 @@ function tripal_analysis_blast_install() {
      );
    }
 
-   $term = tripal_insert_cvterm(array(
-     'id' => 'format:1333',
-     'name' => 'BLAST results',
-     'cv_name' => 'EDAM',
-     'definition' => 'Format of results of a sequence database search using some variant of BLAST. This includes score data, alignment data and summary table.',
-   ));
-
    // Create 'Analysis Blast' entity type
    tripal_analysis_blast_create_entity_type();
 }
@@ -443,7 +436,18 @@ function tripal_analysis_blast_add_cvterms() {
 /**
  * Create Analysis Blast Entity Type
  */
+
+
 function tripal_analysis_blast_create_entity_type () {
+
+
+  $term = tripal_insert_cvterm(array(
+    'id' => 'format:1333',
+    'name' => 'BLAST results',
+    'cv_name' => 'EDAM',
+    'definition' => 'Format of results of a sequence database search using some variant of BLAST. This includes score data, alignment data and summary table.',
+  ));
+
   $error = '';
   $args = array(
     'vocabulary' => 'format',


### PR DESCRIPTION
resolves
```
 WD tripal_chado: chado_select_record: the foreign key definition for [error]
'cv_id' on table 'cvterm' returned no results where the definition
supplied was Array
(
    [name] => format
)

[site http://default] [TRIPAL ERROR] [TRIPAL_CHADO] chado_select_record: the foreign key definition for 'cv_id' on table 'cvterm' returned no results where the definition supplied was Array(    [name] => format)
PDOException: SQLSTATE[23502]: Not null violation: 7 ERROR:  null    [error]
```
as described in #10 .  In short, it was a pesky CV/DB mixup.  `tripal_load_term_entity()` was looking for the CV format instead of EDAM.