### PR TITLE
Fix term_vocabulary issue

### DIFF
--- a/includes/TripalFields/format__blast_results/format__blast_results.inc
+++ b/includes/TripalFields/format__blast_results/format__blast_results.inc
@@ -15,7 +15,7 @@ class format__blast_results extends ChadoField {
   // If you override this variable in a child class be sure to replicate the
   // term_name, term_vocab, term_accession and term_fixed keys as these are
   // required for all TripalFields.
-  public static $default_instance_settings  = array(
+  public static $default_settings  = array(
     // The short name for the vocabulary (e.g. shcema, SO, GO, PATO, etc.).
     'term_vocabulary' => 'format',
     // The name of the term.

--- a/includes/TripalFields/format__blast_results/format__blast_results.inc
+++ b/includes/TripalFields/format__blast_results/format__blast_results.inc
@@ -15,7 +15,7 @@ class format__blast_results extends ChadoField {
   // If you override this variable in a child class be sure to replicate the
   // term_name, term_vocab, term_accession and term_fixed keys as these are
   // required for all TripalFields.
-  public static $default_settings  = array(
+  public static $default_instance_settings  = array(
     // The short name for the vocabulary (e.g. shcema, SO, GO, PATO, etc.).
     'term_vocabulary' => 'format',
     // The name of the term.

--- a/includes/tripal_analysis_blast.fields.inc
+++ b/includes/tripal_analysis_blast.fields.inc
@@ -54,6 +54,9 @@ function tripal_analysis_blast_bundle_instances_info($entity_type, $bundle) {
         'chado_table' => 'analysis_feature',
         'chado_column' => '',
         'base_table' => 'feature',
+        'term_vocabulary' => 'format',
+        'term_name' => 'BLAST results',
+        'term_accession' => '1333',
       ),
       'widget' => array(
         'type' => 'format__blast_results_widget',


### PR DESCRIPTION
Hello,

This PR fixes the following error:
```
The field instance, format__blast_results, is missing the "term_vocabulary" setting. The field instance cannot be added. Please check the field settings.
```

The error shows up when clicking the `+ check for new fields` link on the `manage fields` page.

Thanks!