### PR TITLE
Make sure DB exists and fix typo

### DIFF
--- a/includes/TripalFields/format__blast_results/format__blast_results_formatter.inc
+++ b/includes/TripalFields/format__blast_results/format__blast_results_formatter.inc
@@ -78,6 +78,10 @@ class format__blast_results_formatter extends ChadoFieldFormatter {
       $pager_id      = $feature_pager_id + $i;
       $total_records = count($hits_array);
 
+      if(empty($db->name)) {
+        $db->name = "Database not found";
+      }
+      
       $current_page_num = pager_default_initialize($total_records, $num_results_per_page, $pager_id);
       $offset = $num_results_per_page * $current_page_num;
 
@@ -208,7 +212,7 @@ class format__blast_results_formatter extends ChadoFieldFormatter {
 
       // if there are no results then print a nice message
       if ($total_records == 0) {
-        $row[] = array(
+        $rows[] = array(
           array(
             'data' => "There are no matches against " . $db->name . " for this " . $feature->type_id->name . ".",
             'colspan' => '5'


### PR DESCRIPTION
Turns out there was a simple typo in the code that prevented the message "No hits found" from getting displayed. That's fixed here.

Also added a check to make sure that `$db->name` contains a not found message if the db is empty.

Thanks!