### PR TITLE
Fix collapse fieldset script

### DIFF
--- a/includes/TripalFields/format__blast_results/format__blast_results_formatter.inc
+++ b/includes/TripalFields/format__blast_results/format__blast_results_formatter.inc
@@ -77,14 +77,17 @@ class format__blast_results_formatter extends ChadoFieldFormatter {
       $element[0][$i] = [
         '#type' => 'fieldset',
         '#title' => $analysis->name,
-        '#attached' => ['library' => [
-            ['system', 'drupal.collapse']
-          ]
+        '#collapsed' => TRUE,
+        '#collapsible' => TRUE,
+        '#attached' => [
+          'js' => [
+            ['misc/collapse.js', 'misc/form.js'],
+          ],
         ],
         '#attributes' => [
-          'class' => ['collapsible', 'collapsed']
-        ]
-        ];
+          'class' => ['collapsible', 'collapsed'],
+        ],
+      ];
 
       $content = '
           <p>

--- a/includes/TripalFields/format__blast_results/format__blast_results_formatter.inc
+++ b/includes/TripalFields/format__blast_results/format__blast_results_formatter.inc
@@ -80,8 +80,8 @@ class format__blast_results_formatter extends ChadoFieldFormatter {
         '#collapsed' => TRUE,
         '#collapsible' => TRUE,
         '#attached' => [
-          'js' => [
-            ['misc/collapse.js', 'misc/form.js'],
+          'library' => [
+            ['system', 'drupal.collapse'],
           ],
         ],
         '#attributes' => [


### PR DESCRIPTION
This addresses the issue with fieldset on Bootstrap 3 based themes. The fix basically implements the same method as that in [tripal_add_page()](https://github.com/tripal/tripal/blob/0338beea99354475150f368da08a0bb3fac2c1ff/tripal/includes/TripalEntityUIController.inc#L772-L784)

Thanks!