### PR TITLE
Database field is now required

### DIFF
--- a/includes/TripalImporter/BlastImporter.inc
+++ b/includes/TripalImporter/BlastImporter.inc
@@ -106,6 +106,7 @@ class BlastImporter extends TripalImporter {
               '!settings' => l('Blast Settings', 'admin/tripal/extension/tripal_blast_analysis', array('attributes' => array('target' => '_blank')))
             ]),
         '#options' => $form['db_options']['#value'],
+        '#required' => TRUE,
         '#default_value' => $blastdb,
     );
 


### PR DESCRIPTION
Just added a required line to the database field in the form. Tested by removing all configured databases and trying to run the loader; it failed at validation.